### PR TITLE
improve(camel-common): generate OSGi compatible manifest file

### DIFF
--- a/camunda-bpm-camel-common/pom.xml
+++ b/camunda-bpm-camel-common/pom.xml
@@ -50,4 +50,48 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>org.camunda.bpm.camel.*</Export-Package>
+                        <Bundle-Description>${project.description}</Bundle-Description>
+                        <Import-Package>org.apache.camel;version="[2.10,3)",org.apache.camel.impl;version="[2.10,3)",*</Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>cleanVersions</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>


### PR DESCRIPTION
This modification generates proper MANIFEST content to make it possible to use the common artifact in an OSGi container.
