### PR TITLE
feat(common): returns with the id of the new process if started

### DIFF
--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
@@ -108,7 +108,12 @@ public class MessageProducer extends CamundaBpmProducer {
         // workaround for https://app.camunda.com/jira/browse/CAM-1316 - at the moment we just start process instances
         // and skip correlation!
         //runtimeService.correlateMessage(messageName, correlationKeys, processVariables);
-        runtimeService.startProcessInstanceByMessage(messageName, processVariables);
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByMessage(messageName, processVariables);
+
+        //set the processId of the newly created instance
+        if (processInstance != null) {
+          exchange.setProperty(CAMUNDA_BPM_PROCESS_INSTANCE_ID, processInstance.getProcessInstanceId());
+        }
       }
     }
     else {


### PR DESCRIPTION
Sometimes it would be useful to get the instanceId if of the new process which has been started.
