### PR TITLE
An optional type should be available with the CamundaBpmCorrelationKey

### DIFF
--- a/camunda-bpm-camel-common/pom.xml
+++ b/camunda-bpm-camel-common/pom.xml
@@ -85,12 +85,12 @@
                     </instructions>
                 </configuration>
                 <executions>
-                    <execution>
+                    <!-- execution>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>cleanVersions</goal>
                         </goals>
-                    </execution>
+                    </execution-->
                     <execution>
                         <id>bundle-manifest</id>
                         <phase>process-classes</phase>
@@ -102,6 +102,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmConstants.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmConstants.java
@@ -5,26 +5,27 @@ package org.camunda.bpm.camel.component;
  */
 public final class CamundaBpmConstants {
 
-  public static final String CAMUNDA_BPM_CAMEL_URI_SCHEME = "camunda-bpm";
-  public static final String CAMUNDA_BPM_PROCESS_DEFINITION_KEY = "CamundaBpmProcessDefinitionKey";
-  public static final String CAMUNDA_BPM_PROCESS_DEFINITION_ID = "CamundaBpmProcessDefinitionId";
-  public static final String CAMUNDA_BPM_PROCESS_INSTANCE_ID = "CamundaBpmProcessInstanceId";
-  public static final String CAMUNDA_BPM_BUSINESS_KEY = "CamundaBpmBusinessKey";
-  public static final String CAMUNDA_BPM_CORRELATION_KEY = "CamundaBpmCorrelationKey";
+    public static final String CAMUNDA_BPM_CAMEL_URI_SCHEME = "camunda-bpm";
+    public static final String CAMUNDA_BPM_PROCESS_DEFINITION_KEY = "CamundaBpmProcessDefinitionKey";
+    public static final String CAMUNDA_BPM_PROCESS_DEFINITION_ID = "CamundaBpmProcessDefinitionId";
+    public static final String CAMUNDA_BPM_PROCESS_INSTANCE_ID = "CamundaBpmProcessInstanceId";
+    public static final String CAMUNDA_BPM_BUSINESS_KEY = "CamundaBpmBusinessKey";
+    public static final String CAMUNDA_BPM_CORRELATION_KEY = "CamundaBpmCorrelationKey";
+    public static final String CAMUNDA_BPM_CORRELATION_KEY_TYPE = "CamundaBpmCorrelationKeyType";
 
-  /* Apache Camel URI parameters */
-  public final static String PROCESS_DEFINITION_KEY_PARAMETER = "processDefinitionKey";
-  public final static String MESSAGE_NAME_PARAMETER = "messageName";
-  public final static String CORRELATION_KEY_NAME_PARAMETER = "correlationKeyName";
-  public final static String ACTIVITY_ID_PARAMETER = "activityId";
-  public final static String COPY_MESSAGE_PROPERTIES_PARAMETER = "copyProperties";
-  public final static String COPY_MESSAGE_HEADERS_PARAMETER = "copyHeaders";
-  public final static String COPY_MESSAGE_BODY_AS_PROCESS_VARIABLE_PARAMETER = "copyBodyAsVariable";
+    /* Apache Camel URI parameters */
+    public final static String PROCESS_DEFINITION_KEY_PARAMETER = "processDefinitionKey";
+    public final static String MESSAGE_NAME_PARAMETER = "messageName";
+    public final static String CORRELATION_KEY_NAME_PARAMETER = "correlationKeyName";
+    public final static String ACTIVITY_ID_PARAMETER = "activityId";
+    public final static String COPY_MESSAGE_PROPERTIES_PARAMETER = "copyProperties";
+    public final static String COPY_MESSAGE_HEADERS_PARAMETER = "copyHeaders";
+    public final static String COPY_MESSAGE_BODY_AS_PROCESS_VARIABLE_PARAMETER = "copyBodyAsVariable";
 
-  private CamundaBpmConstants() {
-  } // prevent instantiation of helper class
+    private CamundaBpmConstants() {
+    } // prevent instantiation of helper class
 
-  public static String camundaBpmUri(String path) {
-    return CAMUNDA_BPM_CAMEL_URI_SCHEME + ":" + path;
-  }
+    public static String camundaBpmUri(String path) {
+        return CAMUNDA_BPM_CAMEL_URI_SCHEME + ":" + path;
+    }
 }

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
@@ -15,6 +15,7 @@ package org.camunda.bpm.camel.component.producer;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.ACTIVITY_ID_PARAMETER;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_BUSINESS_KEY;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_CORRELATION_KEY;
+import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_CORRELATION_KEY_TYPE;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_PROCESS_INSTANCE_ID;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CORRELATION_KEY_NAME_PARAMETER;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.MESSAGE_NAME_PARAMETER;
@@ -44,135 +45,129 @@ import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
  */
 public class MessageProducer extends CamundaBpmProducer {
 
-  private final String messageName;
-  private final String activityId;
-  private final String processDefinitionKey;
-  private final String correlationKeyName;
+    private final String messageName;
+    private final String activityId;
+    private final String processDefinitionKey;
+    private final String correlationKeyName;
 
-  public MessageProducer(CamundaBpmEndpoint endpoint,
-      Map<String, Object> parameters) {
-    super(endpoint, parameters);
+    public MessageProducer(CamundaBpmEndpoint endpoint, Map<String, Object> parameters) {
+        super(endpoint, parameters);
 
-    if (parameters.containsKey(MESSAGE_NAME_PARAMETER)) {
-      this.messageName = (String) parameters.get(MESSAGE_NAME_PARAMETER);
-      this.activityId = null;
-    } else if (parameters.containsKey(ACTIVITY_ID_PARAMETER)) {
-      this.messageName = null;
-      this.activityId = (String) parameters.get(ACTIVITY_ID_PARAMETER);
-    } else {
-      this.messageName = null;
-      this.activityId = null;
-      throw new IllegalArgumentException("You need to pass the '"
-          + MESSAGE_NAME_PARAMETER + "' parameter! Parameters received: "
-          + parameters);
+        if (parameters.containsKey(MESSAGE_NAME_PARAMETER)) {
+            this.messageName = (String) parameters.get(MESSAGE_NAME_PARAMETER);
+            this.activityId = null;
+        } else if (parameters.containsKey(ACTIVITY_ID_PARAMETER)) {
+            this.messageName = null;
+            this.activityId = (String) parameters.get(ACTIVITY_ID_PARAMETER);
+        } else {
+            this.messageName = null;
+            this.activityId = null;
+            throw new IllegalArgumentException("You need to pass the '" + MESSAGE_NAME_PARAMETER
+                    + "' parameter! Parameters received: " + parameters);
+        }
+        if (parameters.containsKey(PROCESS_DEFINITION_KEY_PARAMETER)) {
+            this.processDefinitionKey = (String) parameters.get(PROCESS_DEFINITION_KEY_PARAMETER);
+        } else {
+            this.processDefinitionKey = null;
+        }
+        if (parameters.containsKey(CORRELATION_KEY_NAME_PARAMETER)) {
+            this.correlationKeyName = (String) parameters.get(CORRELATION_KEY_NAME_PARAMETER);
+        } else {
+            this.correlationKeyName = null;
+        }
     }
-    if (parameters.containsKey(PROCESS_DEFINITION_KEY_PARAMETER)) {
-      this.processDefinitionKey = (String) parameters
-          .get(PROCESS_DEFINITION_KEY_PARAMETER);
-    } else {
-      this.processDefinitionKey = null;
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void process(Exchange exchange) throws Exception {
+        String processInstanceId = exchange.getProperty(CAMUNDA_BPM_PROCESS_INSTANCE_ID, String.class);
+        String businessKey = exchange.getProperty(CAMUNDA_BPM_BUSINESS_KEY, String.class);
+
+        Map<String, Object> processVariables = ExchangeUtils.prepareVariables(exchange, parameters);
+
+        if (messageName != null) {
+            HashMap<String, Object> correlationKeys = new HashMap<String, Object>();
+
+            if (correlationKeyName != null) {
+                Class clazz = String.class;
+                String correlationKeyType = exchange.getProperty(CAMUNDA_BPM_CORRELATION_KEY_TYPE, String.class);
+                if (correlationKeyType != null) {
+                    clazz = Class.forName(correlationKeyType);
+                }
+                Object correlationKey = exchange.getProperty(CAMUNDA_BPM_CORRELATION_KEY, clazz);
+                if (correlationKey == null) {
+                    throw new RuntimeException("Missing value for correlation key for message '" + messageName + "'");
+                }
+                correlationKeys.put(correlationKeyName, correlationKey);
+            }
+
+            // if we have process instance we try to send the message to this
+            // one:
+            if (processInstanceId != null) {
+                ExecutionQuery query = runtimeService.createExecutionQuery() //
+                        .processInstanceId(processInstanceId) //
+                        .messageEventSubscriptionName(messageName);
+                if (processDefinitionKey != null) {
+                    query.processDefinitionKey(processDefinitionKey);
+                }
+                Execution execution = query.singleResult();
+
+                if (execution == null) {
+                    throw new RuntimeException("Couldn't find waiting process instance with id '" + processInstanceId
+                            + "' for message '" + messageName + "'");
+                }
+
+                runtimeService.messageEventReceived(messageName, execution.getId(), processVariables);
+            } else if (businessKey != null) {
+                // if we have businessKey, use it to correlate
+                runtimeService.correlateMessage(messageName, businessKey, correlationKeys, processVariables);
+            } else {
+                // otherwise we just send the message to the engine to let the
+                // engine
+                // decide what to do
+                // this can either correlate to a waiting instance or start a
+                // new
+                // process Instance
+
+                runtimeService.correlateMessage(messageName, correlationKeys, processVariables);
+            }
+        } else {
+            // signal a ReceiveTask needs a processInstance to be addressed
+            // (hint: this should be best done by a message in the ReceiveTask
+            // as this is possible from 7.1 on - this was introduced with 7.0
+            // where this was not yet possible)
+            if (processInstanceId == null && businessKey != null) {
+                ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().processInstanceBusinessKey(
+                        businessKey);
+                if (processDefinitionKey != null) {
+                    query.processDefinitionKey(processDefinitionKey);
+                }
+                ProcessInstance processInstance = query.singleResult();
+                if (processInstance != null) {
+                    processInstanceId = processInstance.getId();
+                }
+            }
+
+            if (processInstanceId == null) {
+                throw new RuntimeException("Could not find the process instance via the provided properties ("
+                        + CAMUNDA_BPM_PROCESS_INSTANCE_ID + "= '" + processInstanceId + "', " + CAMUNDA_BPM_BUSINESS_KEY
+                        + "= '" + businessKey + "'");
+            }
+
+            ExecutionQuery query = runtimeService.createExecutionQuery().processInstanceId(
+                    processInstanceId).activityId(activityId);
+
+            if (processDefinitionKey != null) {
+                query.processDefinitionKey(processDefinitionKey);
+            }
+            Execution execution = query.singleResult();
+
+            if (execution == null) {
+                throw new RuntimeException("Couldn't find process instance with id '" + processInstanceId
+                        + "' waiting in activity '" + activityId + "'");
+            }
+
+            runtimeService.signal(execution.getId(), processVariables);
+        }
     }
-    if (parameters.containsKey(CORRELATION_KEY_NAME_PARAMETER)) {
-      this.correlationKeyName = (String) parameters
-          .get(CORRELATION_KEY_NAME_PARAMETER);
-    } else {
-      this.correlationKeyName = null;
-    }
-  }
-
-  @Override
-  public void process(Exchange exchange) throws Exception {
-    String processInstanceId = exchange.getProperty(
-        CAMUNDA_BPM_PROCESS_INSTANCE_ID, String.class);
-    String businessKey = exchange.getProperty(CAMUNDA_BPM_BUSINESS_KEY,
-        String.class);
-
-    Map<String, Object> processVariables = ExchangeUtils.prepareVariables(
-        exchange, parameters);
-
-    if (messageName != null) {
-      HashMap<String, Object> correlationKeys = new HashMap<String, Object>();
-      if (correlationKeyName != null) {
-        String correlationKey = exchange.getProperty(
-            CAMUNDA_BPM_CORRELATION_KEY, String.class);
-        if (correlationKey == null) {
-          throw new RuntimeException(
-              "Missing value for correlation key for message '" + messageName
-                  + "'");
-        }
-        correlationKeys.put(correlationKeyName, correlationKey);
-      }
-
-      // if we have process instance we try to send the message to this one:
-      if (processInstanceId != null) {
-        ExecutionQuery query = runtimeService.createExecutionQuery() //
-            .processInstanceId(processInstanceId) //
-            .messageEventSubscriptionName(messageName);
-        if (processDefinitionKey != null) {
-          query.processDefinitionKey(processDefinitionKey);
-        }
-        Execution execution = query.singleResult();
-
-        if (execution == null) {
-          throw new RuntimeException(
-              "Couldn't find waiting process instance with id '"
-                  + processInstanceId + "' for message '" + messageName + "'");
-        }
-
-        runtimeService.messageEventReceived(messageName, execution.getId(),
-            processVariables);
-      } else if (businessKey != null) {
-        // if we have businessKey, use it to correlate
-        runtimeService.correlateMessage(messageName, businessKey,
-            correlationKeys, processVariables);
-      } else {
-        // otherwise we just send the message to the engine to let the engine
-        // decide what to do
-        // this can either correlate to a waiting instance or start a new
-        // process Instance
-
-        runtimeService.correlateMessage(messageName, correlationKeys,
-            processVariables);
-      }
-    } else {
-      // signal a ReceiveTask needs a processInstance to be addressed
-      // (hint: this should be best done by a message in the ReceiveTask
-      // as this is possible from 7.1 on - this was introduced with 7.0
-      // where this was not yet possible)
-      if (processInstanceId == null && businessKey != null) {
-        ProcessInstanceQuery query = runtimeService
-            .createProcessInstanceQuery().processInstanceBusinessKey(
-                businessKey);
-        if (processDefinitionKey != null) {
-          query.processDefinitionKey(processDefinitionKey);
-        }
-        ProcessInstance processInstance = query.singleResult();
-        if (processInstance != null) {
-          processInstanceId = processInstance.getId();
-        }
-      }
-
-      if (processInstanceId == null) {
-        throw new RuntimeException(
-            "Could not find the process instance via the provided properties ("
-                + CAMUNDA_BPM_PROCESS_INSTANCE_ID + "= '" + processInstanceId
-                + "', " + CAMUNDA_BPM_BUSINESS_KEY + "= '" + businessKey + "'");
-      }
-
-      ExecutionQuery query = runtimeService.createExecutionQuery()
-          .processInstanceId(processInstanceId).activityId(activityId);
-
-      if (processDefinitionKey != null) {
-        query.processDefinitionKey(processDefinitionKey);
-      }
-      Execution execution = query.singleResult();
-
-      if (execution == null) {
-        throw new RuntimeException("Couldn't find process instance with id '"
-            + processInstanceId + "' waiting in activity '" + activityId + "'");
-      }
-
-      runtimeService.signal(execution.getId(), processVariables);
-    }
-  }
 }

--- a/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/component/producer/MessageProducerTest.java
+++ b/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/component/producer/MessageProducerTest.java
@@ -3,6 +3,7 @@ package org.camunda.bpm.camel.component.producer;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.ACTIVITY_ID_PARAMETER;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_BUSINESS_KEY;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_CORRELATION_KEY;
+import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_CORRELATION_KEY_TYPE;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CAMUNDA_BPM_PROCESS_INSTANCE_ID;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.CORRELATION_KEY_NAME_PARAMETER;
 import static org.camunda.bpm.camel.component.CamundaBpmConstants.MESSAGE_NAME_PARAMETER;
@@ -33,244 +34,254 @@ import org.mockito.ArgumentCaptor;
 
 public class MessageProducerTest extends BaseCamelTest {
 
-  @Test
-  public void getSignalProcessProducerFromUri() throws Exception {
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "="
-            + "anActivityId"));
-    Producer producer = endpoint.createProducer();
-    assertThat(producer).isInstanceOf(MessageProducer.class);
-  }
+    @Test
+    public void getSignalProcessProducerFromUri() throws Exception {
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "=" + "anActivityId"));
+        Producer producer = endpoint.createProducer();
+        assertThat(producer).isInstanceOf(MessageProducer.class);
+    }
 
-  @Test
-  public void messageIsDeliveredCalled() throws Exception {
-    ProcessInstance processInstance = mock(ProcessInstance.class);
-    when(processInstance.getProcessInstanceId()).thenReturn(
-        "theProcessInstanceId");
-    when(processInstance.getProcessDefinitionId()).thenReturn(
-        "theProcessDefinitionId");
-    when(
-        runtimeService.startProcessInstanceByKey(eq("aProcessDefinitionKey"),
-            anyMap())).thenReturn(processInstance);
+    @Test
+    public void messageIsDeliveredCalled() throws Exception {
+        ProcessInstance processInstance = mock(ProcessInstance.class);
+        when(processInstance.getProcessInstanceId()).thenReturn("theProcessInstanceId");
+        when(processInstance.getProcessDefinitionId()).thenReturn("theProcessDefinitionId");
+        when(runtimeService.startProcessInstanceByKey(eq("aProcessDefinitionKey"), anyMap())).thenReturn(
+                processInstance);
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "="
-            + "anActivityId"));
-    Producer producer = endpoint.createProducer();
-    assertThat(producer).isInstanceOf(MessageProducer.class);
-  }
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "=" + "anActivityId"));
+        Producer producer = endpoint.createProducer();
+        assertThat(producer).isInstanceOf(MessageProducer.class);
+    }
 
-  @Test
-  public void signalCalled() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
-    ExecutionQuery query = mock(ExecutionQuery.class);
-    Execution execution = mock(Execution.class);
+    @Test
+    public void signalCalled() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
+        ExecutionQuery query = mock(ExecutionQuery.class);
+        Execution execution = mock(Execution.class);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(
-        exchange.getProperty(eq(CAMUNDA_BPM_PROCESS_INSTANCE_ID),
-            eq(String.class))).thenReturn("theProcessInstanceId");
-    when(runtimeService.createExecutionQuery()).thenReturn(query);
-    when(query.processInstanceId(anyString())).thenReturn(query);
-    when(query.activityId(anyString())).thenReturn(query);
-    when(query.singleResult()).thenReturn(execution);
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_PROCESS_INSTANCE_ID), eq(String.class))).thenReturn(
+                "theProcessInstanceId");
+        when(runtimeService.createExecutionQuery()).thenReturn(query);
+        when(query.processInstanceId(anyString())).thenReturn(query);
+        when(query.activityId(anyString())).thenReturn(query);
+        when(query.singleResult()).thenReturn(execution);
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "="
-            + "anActivityId"));
-    Producer producer = endpoint.createProducer();
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "=" + "anActivityId"));
+        Producer producer = endpoint.createProducer();
 
-    producer.process(exchange);
+        producer.process(exchange);
 
-    verify(runtimeService).signal(anyString(), anyMap());
-  }
+        verify(runtimeService).signal(anyString(), anyMap());
+    }
 
-  @Test
-  public void signalTransformBusinesskey() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
-    ExecutionQuery query = mock(ExecutionQuery.class);
-    Execution execution = mock(Execution.class);
-    ProcessInstanceQuery piQuery = mock(ProcessInstanceQuery.class);
-    ProcessInstance processInstance = mock(ProcessInstance.class);
+    @Test
+    public void signalTransformBusinesskey() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
+        ExecutionQuery query = mock(ExecutionQuery.class);
+        Execution execution = mock(Execution.class);
+        ProcessInstanceQuery piQuery = mock(ProcessInstanceQuery.class);
+        ProcessInstance processInstance = mock(ProcessInstance.class);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class)))
-        .thenReturn("theBusinessKey");
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class))).thenReturn("theBusinessKey");
 
-    when(runtimeService.createProcessInstanceQuery()).thenReturn(piQuery);
-    when(runtimeService.createExecutionQuery()).thenReturn(query);
-    when(piQuery.processInstanceBusinessKey(anyString())).thenReturn(piQuery);
-    when(piQuery.singleResult()).thenReturn(processInstance);
-    when(processInstance.getId()).thenReturn("theProcessInstanceId");
+        when(runtimeService.createProcessInstanceQuery()).thenReturn(piQuery);
+        when(runtimeService.createExecutionQuery()).thenReturn(query);
+        when(piQuery.processInstanceBusinessKey(anyString())).thenReturn(piQuery);
+        when(piQuery.singleResult()).thenReturn(processInstance);
+        when(processInstance.getId()).thenReturn("theProcessInstanceId");
 
-    when(query.processInstanceId(anyString())).thenReturn(query);
-    when(query.activityId(anyString())).thenReturn(query);
-    when(query.singleResult()).thenReturn(execution);
+        when(query.processInstanceId(anyString())).thenReturn(query);
+        when(query.activityId(anyString())).thenReturn(query);
+        when(query.singleResult()).thenReturn(execution);
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "="
-            + "anActivityId"));
-    Producer producer = endpoint.createProducer();
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + ACTIVITY_ID_PARAMETER + "=" + "anActivityId"));
+        Producer producer = endpoint.createProducer();
 
-    producer.process(exchange);
+        producer.process(exchange);
 
-    verify(piQuery).processInstanceBusinessKey("theBusinessKey");
-    verify(query).processInstanceId("theProcessInstanceId");
-  }
+        verify(piQuery).processInstanceBusinessKey("theBusinessKey");
+        verify(query).processInstanceId("theProcessInstanceId");
+    }
 
-  @Test
-  public void messageProcessInstanceId() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
-    ExecutionQuery query = mock(ExecutionQuery.class);
-    Execution execution = mock(Execution.class);
+    @Test
+    public void messageProcessInstanceId() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
+        ExecutionQuery query = mock(ExecutionQuery.class);
+        Execution execution = mock(Execution.class);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(
-        exchange.getProperty(eq(CAMUNDA_BPM_PROCESS_INSTANCE_ID),
-            eq(String.class))).thenReturn("theProcessInstanceId");
-    when(runtimeService.createExecutionQuery()).thenReturn(query);
-    when(query.processInstanceId(anyString())).thenReturn(query);
-    when(query.messageEventSubscriptionName(anyString())).thenReturn(query);
-    when(query.singleResult()).thenReturn(execution);
-    when(execution.getId()).thenReturn("theExecutionId");
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_PROCESS_INSTANCE_ID), eq(String.class))).thenReturn(
+                "theProcessInstanceId");
+        when(runtimeService.createExecutionQuery()).thenReturn(query);
+        when(query.processInstanceId(anyString())).thenReturn(query);
+        when(query.messageEventSubscriptionName(anyString())).thenReturn(query);
+        when(query.singleResult()).thenReturn(execution);
+        when(execution.getId()).thenReturn("theExecutionId");
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "="
-            + "aMessageName"));
-    Producer producer = endpoint.createProducer();
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName"));
+        Producer producer = endpoint.createProducer();
 
-    producer.process(exchange);
+        producer.process(exchange);
 
-    verify(query).processInstanceId("theProcessInstanceId");
-    verify(query).messageEventSubscriptionName("aMessageName");
+        verify(query).processInstanceId("theProcessInstanceId");
+        verify(query).messageEventSubscriptionName("aMessageName");
 
-    verify(runtimeService).messageEventReceived(eq("aMessageName"),
-        eq("theExecutionId"), anyMap());
-  }
+        verify(runtimeService).messageEventReceived(eq("aMessageName"), eq("theExecutionId"), anyMap());
+    }
 
-  @Test
-  public void messageBusinessKey() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
+    @Test
+    public void messageBusinessKey() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class)))
-        .thenReturn("theBusinessKey");
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class))).thenReturn("theBusinessKey");
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "="
-            + "aMessageName"));
-    Producer producer = endpoint.createProducer();
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName"));
+        Producer producer = endpoint.createProducer();
 
-    producer.process(exchange);
+        producer.process(exchange);
 
-    Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
-    ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor
-        .forClass(mapClass);
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor.forClass(mapClass);
 
-    verify(runtimeService).correlateMessage(eq("aMessageName"),
-        eq("theBusinessKey"), correlationCaptor.capture(), anyMap());
+        verify(runtimeService).correlateMessage(eq("aMessageName"),
+                eq("theBusinessKey"),
+                correlationCaptor.capture(),
+                anyMap());
 
-    assertThat(correlationCaptor.getValue().size()).isEqualTo(0);
-  }
+        assertThat(correlationCaptor.getValue().size()).isEqualTo(0);
+    }
 
-  @Test
-  public void messageBusinessKeyCorrelationKey() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
+    @Test
+    public void messageBusinessKeyCorrelationKey() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class)))
-        .thenReturn("theBusinessKey");
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class))).thenReturn("theBusinessKey");
 
-    when(
-        exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY), eq(String.class)))
-        .thenReturn("theCorrelationKey");
+        when(exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY), eq(String.class))).thenReturn("theCorrelationKey");
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "="
-            + "aMessageName" + "&" + CORRELATION_KEY_NAME_PARAMETER + "="
-            + "aCorrelationKeyName"));
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName" + "&"
+                        + CORRELATION_KEY_NAME_PARAMETER + "=" + "aCorrelationKeyName"));
 
-    Producer producer = endpoint.createProducer();
+        Producer producer = endpoint.createProducer();
 
-    producer.process(exchange);
+        producer.process(exchange);
 
-    Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
-    ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor
-        .forClass(mapClass);
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor.forClass(mapClass);
 
-    verify(runtimeService).correlateMessage(eq("aMessageName"),
-        eq("theBusinessKey"), correlationCaptor.capture(), anyMap());
+        verify(runtimeService).correlateMessage(eq("aMessageName"),
+                eq("theBusinessKey"),
+                correlationCaptor.capture(),
+                anyMap());
 
-    assertThat(correlationCaptor.getValue().size()).isEqualTo(1);
-    assertTrue(correlationCaptor.getValue().keySet()
-        .contains("aCorrelationKeyName"));
-    assertTrue(correlationCaptor.getValue().values()
-        .contains("theCorrelationKey"));
-  }
+        assertThat(correlationCaptor.getValue().size()).isEqualTo(1);
+        assertTrue(correlationCaptor.getValue().keySet().contains("aCorrelationKeyName"));
+        assertTrue(correlationCaptor.getValue().values().contains("theCorrelationKey"));
+    }
 
-  @Test
-  public void messageNoKey() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
+    @Test
+    public void messageBusinessKeyCorrelationKeyType() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
 
-    when(exchange.getIn()).thenReturn(message);
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_BUSINESS_KEY), eq(String.class))).thenReturn("theBusinessKey");
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "="
-            + "aMessageName"));
-    Producer producer = endpoint.createProducer();
+        when(exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY), eq(java.lang.Integer.class))).thenReturn(15);
 
-    producer.process(exchange);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY_TYPE), eq(String.class))).thenReturn(
+                "java.lang.Integer");
 
-    Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
-    ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor
-        .forClass(mapClass);
-    verify(runtimeService).correlateMessage(eq("aMessageName"),
-        correlationCaptor.capture(), anyMapOf(String.class, Object.class));
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(camundaBpmUri(
+                "message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName" + "&" + CORRELATION_KEY_NAME_PARAMETER + "="
+                        + "aCorrelationKeyName" + "&" + CAMUNDA_BPM_CORRELATION_KEY_TYPE + "=java.lang.Integer"));
 
-    assertThat(correlationCaptor.getValue().size()).isEqualTo(0);
-  }
+        Producer producer = endpoint.createProducer();
 
-  @Test
-  public void messageCorrelationKey() throws Exception {
-    Exchange exchange = mock(Exchange.class);
-    Message message = mock(Message.class);
+        producer.process(exchange);
 
-    when(exchange.getIn()).thenReturn(message);
-    when(
-        exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY), eq(String.class)))
-        .thenReturn("theCorrelationKey");
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor.forClass(mapClass);
 
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "="
-            + "aMessageName" + "&" + CORRELATION_KEY_NAME_PARAMETER + "="
-            + "aCorrelationKeyName"));
-    Producer producer = endpoint.createProducer();
+        verify(runtimeService).correlateMessage(eq("aMessageName"),
+                eq("theBusinessKey"),
+                correlationCaptor.capture(),
+                anyMap());
 
-    producer.process(exchange);
+        assertThat(correlationCaptor.getValue().size()).isEqualTo(1);
+        assertTrue(correlationCaptor.getValue().keySet().contains("aCorrelationKeyName"));
+        assertTrue(correlationCaptor.getValue().values().contains(15));
 
-    Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
-    ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor
-        .forClass(mapClass);
-    verify(runtimeService).correlateMessage(eq("aMessageName"),
-        correlationCaptor.capture(), anyMapOf(String.class, Object.class));
+    }
 
-    assertThat(correlationCaptor.getValue().size()).isEqualTo(1);
-    assertTrue(correlationCaptor.getValue().keySet()
-        .contains("aCorrelationKeyName"));
-    assertTrue(correlationCaptor.getValue().values()
-        .contains("theCorrelationKey"));
-  }
+    @Test
+    public void messageNoKey() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailWithoutMessageActivityId() throws Exception {
-    CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext
-        .getEndpoint(camundaBpmUri("message"));
-    endpoint.createProducer();
-  }
+        when(exchange.getIn()).thenReturn(message);
+
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName"));
+        Producer producer = endpoint.createProducer();
+
+        producer.process(exchange);
+
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor.forClass(mapClass);
+        verify(runtimeService).correlateMessage(eq("aMessageName"),
+                correlationCaptor.capture(),
+                anyMapOf(String.class, Object.class));
+
+        assertThat(correlationCaptor.getValue().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void messageCorrelationKey() throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
+
+        when(exchange.getIn()).thenReturn(message);
+        when(exchange.getProperty(eq(CAMUNDA_BPM_CORRELATION_KEY), eq(String.class))).thenReturn("theCorrelationKey");
+
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(
+                camundaBpmUri("message?" + MESSAGE_NAME_PARAMETER + "=" + "aMessageName" + "&"
+                        + CORRELATION_KEY_NAME_PARAMETER + "=" + "aCorrelationKeyName"));
+        Producer producer = endpoint.createProducer();
+
+        producer.process(exchange);
+
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>) (Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> correlationCaptor = ArgumentCaptor.forClass(mapClass);
+        verify(runtimeService).correlateMessage(eq("aMessageName"),
+                correlationCaptor.capture(),
+                anyMapOf(String.class, Object.class));
+
+        assertThat(correlationCaptor.getValue().size()).isEqualTo(1);
+        assertTrue(correlationCaptor.getValue().keySet().contains("aCorrelationKeyName"));
+        assertTrue(correlationCaptor.getValue().values().contains("theCorrelationKey"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailWithoutMessageActivityId() throws Exception {
+        CamundaBpmEndpoint endpoint = (CamundaBpmEndpoint) camelContext.getEndpoint(camundaBpmUri("message"));
+        endpoint.createProducer();
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>camunda BPM Maven Snapshot Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots</url>
+      <url>https://public.phactum.at/nexus/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
       <id>camunda-nexus</id>


### PR DESCRIPTION
When sending the CamundaBpmCorrelationKey, it is automatically extracted as a String from the properties. This should be the default value. We added a new constant "CamundaBpmCorrelationKeyType" where e.g. the value "java.lang.Long" can be passed. This saves us from parsing the String over and over in out code, since we know it is a Long.

It was a minor fix in the org.camunda.bpm.camel.component.producer.MessageProducer class. 
Tests were added and a new constant in org.camunda.bpm.camel.component.CamundaBpmConstants (CAMUNDA_BPM_CORRELATION_KEY_TYPE)
