### PR TITLE
Camel update 3 2 0

### DIFF
--- a/camunda-bpm-camel-cdi/pom.xml
+++ b/camunda-bpm-camel-cdi/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>jcl-over-slf4j</artifactId>
       <version>${sl4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${sl4j.version}</version>
+    </dependency>
 
     <!-- Apache Camel -->
     <dependency>

--- a/camunda-bpm-camel-cdi/src/test/java/org/camunda/bpm/camel/cdi/ArquillianTestsProcessApplication.java
+++ b/camunda-bpm-camel-cdi/src/test/java/org/camunda/bpm/camel/cdi/ArquillianTestsProcessApplication.java
@@ -4,13 +4,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.camunda.bpm.application.ProcessApplication;
 import org.camunda.bpm.application.ProcessApplicationInterface;
 import org.camunda.bpm.application.impl.EjbProcessApplication;
-import org.jboss.as.ee.component.InjectionTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ejb.*;
 import javax.inject.Inject;
-import java.util.logging.Logger;
 
 /**
  * We need this class because @Startup annotations are lazily instantiated and not *really* initalized at
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 @Local(ProcessApplicationInterface.class)
 public class ArquillianTestsProcessApplication extends EjbProcessApplication {
 
-  Logger log = Logger.getLogger(getClass().getName());
+  private static final Logger LOG = LoggerFactory.getLogger(ArquillianTestsProcessApplication.class);
 
   @Inject
   CamelContextBootstrap camelContext;
@@ -38,9 +38,9 @@ public class ArquillianTestsProcessApplication extends EjbProcessApplication {
 
   @PostConstruct
   public void start() throws Exception {
-    log.info(">>");
-    log.info(">> Starting the ArquillianTestsProcessApplication ");
-    log.info(">>");
+    LOG.info(">>");
+    LOG.info(">> Starting the ArquillianTestsProcessApplication ");
+    LOG.info(">>");
 
     camelContext.addRoute(testRoute);
     camelContext.start();

--- a/camunda-bpm-camel-cdi/src/test/java/org/camunda/bpm/camel/cdi/CamelContextBootstrap.java
+++ b/camunda-bpm-camel-cdi/src/test/java/org/camunda/bpm/camel/cdi/CamelContextBootstrap.java
@@ -4,6 +4,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.cdi.CdiCamelContext;
 import org.camunda.bpm.camel.component.CamundaBpmComponent;
+import org.camunda.bpm.camel.component.CamundaBpmEndpointDefaultImpl;
 import org.camunda.bpm.engine.ProcessEngine;
 
 import javax.annotation.PostConstruct;
@@ -11,7 +12,8 @@ import javax.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.inject.Inject;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Camel context for CDI tests.
@@ -30,7 +32,7 @@ import java.util.logging.Logger;
 @Startup
 public class CamelContextBootstrap {
 
-    Logger log = Logger.getLogger(getClass().getName());
+    private static final Logger LOG = LoggerFactory.getLogger(CamelContextBootstrap.class);
 
     @Inject
     CdiCamelContext camelCtx;
@@ -40,36 +42,36 @@ public class CamelContextBootstrap {
 
     @PostConstruct
     public void init() throws Exception {
-        log.info(">>");
-        log.info(">> Starting Apache Camel's context");
-        log.info(">>");
+        LOG.info(">>");
+        LOG.info(">> Starting Apache Camel's context");
+        LOG.info(">>");
 
-        log.info(">>");
-        log.info(">> Registering camunda BPM component in Camel context");
-        log.info(">>");
+        LOG.info(">>");
+        LOG.info(">> Registering camunda BPM component in Camel context");
+        LOG.info(">>");
         CamundaBpmComponent component = new CamundaBpmComponent(processEngine);
         component.setCamelContext(camelCtx);
         camelCtx.addComponent("camunda-bpm", component);
     }
 
     public void addRoute(RouteBuilder route) throws Exception {
-        log.info(">>");
-        log.info(">> Registering Camel route");
-        log.info(">>");
+        LOG.info(">>");
+        LOG.info(">> Registering Camel route");
+        LOG.info(">>");
         camelCtx.addRoutes(route);
     }
 
     public void start() throws Exception {
         camelCtx.start();
-        log.info(">>");
-        log.info(">> Camel context started");
-        log.info(">>");
+        LOG.info(">>");
+        LOG.info(">> Camel context started");
+        LOG.info(">>");
     }
 
     @PreDestroy
     public void stop() throws Exception {
         camelCtx.stop();
-        log.info(">> Camel context stopped");
+        LOG.info(">> Camel context stopped");
     }
 
     public CamelContext getCamelContext() {

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/common/ExchangeUtils.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/common/ExchangeUtils.java
@@ -14,11 +14,11 @@ package org.camunda.bpm.camel.common;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.camel.Exchange;
 import org.camunda.bpm.camel.component.CamundaBpmConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class contains one method - prepareVariables - that is used to copy
@@ -29,7 +29,7 @@ import org.camunda.bpm.camel.component.CamundaBpmConstants;
  */
 public class ExchangeUtils {
 
-    private static final Logger log = Logger.getLogger(ExchangeUtils.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(ExchangeUtils.class);
 
     /**
      * Copies variables from Camel into the process engine.
@@ -75,8 +75,7 @@ public class ExchangeUtils {
             }
 
         } else if (camelBody != null) {
-            log.log(Level.WARNING,
-                    "unkown type of camel body - not handed over to process engine: " + camelBody.getClass());
+            LOG.warn("unkown type of camel body - not handed over to process engine: " + camelBody.getClass());
         }
 
         return processVariables;

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmEndpointDefaultImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmEndpointDefaultImpl.java
@@ -22,6 +22,8 @@ import org.apache.camel.support.DefaultEndpoint;
 import org.camunda.bpm.camel.common.UriUtils.ParsedUri;
 import org.camunda.bpm.camel.component.producer.CamundaBpmProducerFactory;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class has been modified to be consistent with the changes to
@@ -34,6 +36,8 @@ import org.camunda.bpm.engine.ProcessEngine;
  * @author Ryan Johnston (@rjfsu), Tijs Rademakers
  */
 public class CamundaBpmEndpointDefaultImpl extends DefaultEndpoint implements CamundaBpmEndpoint {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CamundaBpmEndpointDefaultImpl.class);
 
     private CamundaBpmComponent component;
     private Map<String, Object> parameters;
@@ -67,7 +71,7 @@ public class CamundaBpmEndpointDefaultImpl extends DefaultEndpoint implements Ca
 
     @Override
     public void close() {
-        log.info("Closing CamundaBpmEndpointDefaultImpl");
+        LOG.info("Closing CamundaBpmEndpointDefaultImpl");
         super.stop();
     }
 

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmEndpointDefaultImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmEndpointDefaultImpl.java
@@ -45,9 +45,7 @@ public class CamundaBpmEndpointDefaultImpl extends DefaultEndpoint implements Ca
 
     public CamundaBpmEndpointDefaultImpl(String uri, ParsedUri parsedUri, CamundaBpmComponent component,
             Map<String, Object> parameters) {
-        super();
-        setCamelContext(component.getCamelContext());
-        setEndpointUri(uri);
+        super(uri, component);
         this.uri = parsedUri;
         this.component = component;
         this.parameters = parameters;

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
@@ -33,7 +33,7 @@ import org.camunda.bpm.model.xml.impl.util.StringUtil;
 
 public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpoint implements CamundaBpmEndpoint {
 
-    private static final Logger logger = Logger.getLogger(
+    private static final Logger LOG = Logger.getLogger(
             CamundaBpmPollExternalTasksEndpointImpl.class.getCanonicalName());
 
     private CamundaBpmComponent component;
@@ -126,7 +126,7 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
             this.deserializeVariables = Boolean.parseBoolean(
                     (String) parameters.remove(DESERIALIZEVARIABLES_PARAMETER));
             if (!BatchConsumer.systemKnowsDeserializationOfVariables() && this.deserializeVariables) {
-                logger.warning("Parameter '" + DESERIALIZEVARIABLES_PARAMETER
+                LOG.warning("Parameter '" + DESERIALIZEVARIABLES_PARAMETER
                         + "' is set to 'true' but this setting will be ignored in this environment since the "
                         + " version of runtime Camunda is below 7.6.0!");
             }
@@ -138,7 +138,7 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
 
     @Override
     public void close() {
-        log.info("Closing CamundaBpmPollExternalTasksEndpointImpl");
+        LOG.info("Closing CamundaBpmPollExternalTasksEndpointImpl");
         super.stop();
     }
 

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
@@ -19,7 +19,6 @@ import static org.camunda.bpm.camel.component.CamundaBpmConstants.DESERIALIZEVAR
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.PollingConsumer;
@@ -30,10 +29,12 @@ import org.apache.camel.support.DefaultPollingEndpoint;
 import org.camunda.bpm.camel.component.externaltasks.BatchConsumer;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.model.xml.impl.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpoint implements CamundaBpmEndpoint {
 
-    private static final Logger LOG = Logger.getLogger(
+    private static final Logger LOG = LoggerFactory.getLogger(
             CamundaBpmPollExternalTasksEndpointImpl.class.getCanonicalName());
 
     private CamundaBpmComponent component;
@@ -126,7 +127,7 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
             this.deserializeVariables = Boolean.parseBoolean(
                     (String) parameters.remove(DESERIALIZEVARIABLES_PARAMETER));
             if (!BatchConsumer.systemKnowsDeserializationOfVariables() && this.deserializeVariables) {
-                LOG.warning("Parameter '" + DESERIALIZEVARIABLES_PARAMETER
+                LOG.warn("Parameter '" + DESERIALIZEVARIABLES_PARAMETER
                         + "' is set to 'true' but this setting will be ignored in this environment since the "
                         + " version of runtime Camunda is below 7.6.0!");
             }

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
@@ -25,7 +25,7 @@ import org.apache.camel.Consumer;
 import org.apache.camel.PollingConsumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
-import org.apache.camel.converter.TimePatternConverter;
+import org.apache.camel.catalog.impl.TimePatternConverter;
 import org.apache.camel.support.DefaultPollingEndpoint;
 import org.camunda.bpm.camel.component.externaltasks.BatchConsumer;
 import org.camunda.bpm.engine.ProcessEngine;

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmProcessExternalTaskEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmProcessExternalTaskEndpointImpl.java
@@ -16,8 +16,11 @@ import org.apache.camel.converter.TimePatternConverter;
 import org.apache.camel.support.ProcessorEndpoint;
 import org.camunda.bpm.camel.component.externaltasks.TaskProcessor;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CamundaBpmProcessExternalTaskEndpointImpl extends ProcessorEndpoint implements CamundaBpmEndpoint {
+    private static final Logger LOG = LoggerFactory.getLogger(CamundaBpmProcessExternalTaskEndpointImpl.class);
 
     private CamundaBpmComponent component;
 
@@ -88,7 +91,7 @@ public class CamundaBpmProcessExternalTaskEndpointImpl extends ProcessorEndpoint
 
     @Override
     public void close() {
-        log.info("Closing CamundaBpmProcessExternalTaskEndpointImpl");
+        LOG.info("Closing CamundaBpmProcessExternalTaskEndpointImpl");
         this.stop();
     }
 

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmProcessExternalTaskEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmProcessExternalTaskEndpointImpl.java
@@ -12,7 +12,7 @@ import static org.camunda.bpm.camel.component.CamundaBpmConstants.WORKERID_PARAM
 import java.util.Map;
 
 import org.apache.camel.Processor;
-import org.apache.camel.converter.TimePatternConverter;
+import org.apache.camel.catalog.impl.TimePatternConverter;
 import org.apache.camel.support.ProcessorEndpoint;
 import org.camunda.bpm.camel.component.externaltasks.TaskProcessor;
 import org.camunda.bpm.engine.ProcessEngine;

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/BatchConsumer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/BatchConsumer.java
@@ -29,8 +29,11 @@ import org.camunda.bpm.camel.component.CamundaBpmEndpoint;
 import org.camunda.bpm.engine.ExternalTaskService;
 import org.camunda.bpm.engine.externaltask.ExternalTaskQueryTopicBuilder;
 import org.camunda.bpm.engine.externaltask.LockedExternalTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BatchConsumer extends ScheduledBatchPollingConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(BatchConsumer.class);
 
     private final CamundaBpmEndpoint camundaEndpoint;
 
@@ -115,7 +118,7 @@ public class BatchConsumer extends ScheduledBatchPollingConsumer {
 
     @Override
     public void close() {
-        log.info("Closing BatchConsumer");
+        LOG.info("Closing BatchConsumer");
         this.stop();
     }
 

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/BatchConsumer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/BatchConsumer.java
@@ -14,14 +14,7 @@ import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.camel.AsyncCallback;
-import org.apache.camel.AsyncProcessor;
-import org.apache.camel.Exchange;
-import org.apache.camel.ExchangePattern;
-import org.apache.camel.Message;
-import org.apache.camel.PollingConsumer;
-import org.apache.camel.Processor;
-import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.*;
 import org.apache.camel.support.ScheduledBatchPollingConsumer;
 import org.apache.camel.util.CastUtils;
 import org.camunda.bpm.camel.common.CamundaUtils;
@@ -252,7 +245,7 @@ public class BatchConsumer extends ScheduledBatchPollingConsumer {
             for (final LockedExternalTask task : tasks) {
 
                 final ExchangePattern pattern = completeTask ? ExchangePattern.InOut : ExchangePattern.InOnly;
-                Exchange exchange = getEndpoint().createExchange(pattern);
+                ExtendedExchange exchange = getEndpoint().createExchange(pattern).adapt(ExtendedExchange.class);
 
                 exchange.setFromEndpoint(getEndpoint());
                 exchange.setExchangeId(task.getWorkerId() + "/" + task.getId());

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
@@ -10,10 +10,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.Processor;
-import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.*;
 import org.apache.camel.spi.Synchronization;
 import org.camunda.bpm.camel.common.CamundaUtils;
 import org.camunda.bpm.camel.component.CamundaBpmEndpoint;
@@ -72,7 +69,7 @@ public class TaskProcessor implements Processor {
             setInHeaders(exchange);
 
             final TaskProcessor taskProcessor = this;
-            exchange.addOnCompletion(new Synchronization() {
+            exchange.adapt(ExtendedExchange.class).addOnCompletion(new Synchronization() {
 
                 @Override
                 public void onFailure(final Exchange exchange) {

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
@@ -23,7 +23,7 @@ import org.camunda.bpm.engine.externaltask.LockedExternalTask;
 
 public class TaskProcessor implements Processor {
 
-    private static final Logger logger = Logger.getLogger(TaskProcessor.class.getCanonicalName());
+    private static final Logger LOG = Logger.getLogger(TaskProcessor.class.getCanonicalName());
 
     private final CamundaBpmEndpoint camundaEndpoint;
 
@@ -138,7 +138,7 @@ public class TaskProcessor implements Processor {
         if (exchange.isFailed()) {
 
             if (task == null) {
-                logger.warning(
+                LOG.warning(
                         "Processing failed but the task seems to be already processed - will do nothing! Camnda external task id: '"
                                 + taskId + "'");
                 return;
@@ -172,7 +172,7 @@ public class TaskProcessor implements Processor {
             final String errorCode = out.getBody(String.class);
 
             if (task == null) {
-                logger.warning("Should complete the external task with BPM error '" + errorCode
+                LOG.warning("Should complete the external task with BPM error '" + errorCode
                         + "' but the task seems to be already processed - will do nothing! Camnda external task id: '"
                         + taskId + "'");
                 return;
@@ -196,7 +196,7 @@ public class TaskProcessor implements Processor {
         {
 
             if (task == null) {
-                logger.warning("Should complete the external task but the task seems to be "
+                LOG.warning("Should complete the external task but the task seems to be "
                         + "already processed - will do nothing! Camnda external task id: '" + taskId + "'");
                 return;
             }

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/externaltasks/TaskProcessor.java
@@ -8,7 +8,6 @@ import static org.camunda.bpm.camel.component.CamundaBpmConstants.EXCHANGE_RESPO
 
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.logging.Logger;
 
 import org.apache.camel.*;
 import org.apache.camel.spi.Synchronization;
@@ -17,10 +16,12 @@ import org.camunda.bpm.camel.component.CamundaBpmEndpoint;
 import org.camunda.bpm.engine.ExternalTaskService;
 import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.externaltask.LockedExternalTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TaskProcessor implements Processor {
 
-    private static final Logger LOG = Logger.getLogger(TaskProcessor.class.getCanonicalName());
+    private static final Logger LOG = LoggerFactory.getLogger(TaskProcessor.class.getCanonicalName());
 
     private final CamundaBpmEndpoint camundaEndpoint;
 
@@ -135,7 +136,7 @@ public class TaskProcessor implements Processor {
         if (exchange.isFailed()) {
 
             if (task == null) {
-                LOG.warning(
+                LOG.warn(
                         "Processing failed but the task seems to be already processed - will do nothing! Camnda external task id: '"
                                 + taskId + "'");
                 return;
@@ -169,7 +170,7 @@ public class TaskProcessor implements Processor {
             final String errorCode = out.getBody(String.class);
 
             if (task == null) {
-                LOG.warning("Should complete the external task with BPM error '" + errorCode
+                LOG.warn("Should complete the external task with BPM error '" + errorCode
                         + "' but the task seems to be already processed - will do nothing! Camnda external task id: '"
                         + taskId + "'");
                 return;
@@ -191,9 +192,8 @@ public class TaskProcessor implements Processor {
         } else
         // success
         {
-
             if (task == null) {
-                LOG.warning("Should complete the external task but the task seems to be "
+                LOG.warn("Should complete the external task but the task seems to be "
                         + "already processed - will do nothing! Camnda external task id: '" + taskId + "'");
                 return;
             }

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/MessageProducer.java
@@ -31,6 +31,8 @@ import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ExecutionQuery;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sends a message (or signals a ReceiveTask) to a waiting process instance or
@@ -44,6 +46,8 @@ import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
  * @author Bernd Ruecker
  */
 public class MessageProducer extends CamundaBpmProducer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageProducer.class);
 
     private final String messageName;
     private final String activityId;
@@ -79,7 +83,7 @@ public class MessageProducer extends CamundaBpmProducer {
 
     @Override
     public void close() {
-        log.info("Closing MessageProducer");
+        LOG.info("Closing MessageProducer");
         this.stop();
     }
 

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/StartProcessProducer.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/producer/StartProcessProducer.java
@@ -16,6 +16,8 @@ import org.apache.camel.Exchange;
 import org.camunda.bpm.camel.common.ExchangeUtils;
 import org.camunda.bpm.camel.component.CamundaBpmEndpoint;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +36,8 @@ import static org.camunda.bpm.camel.component.CamundaBpmConstants.*;
  */
 public class StartProcessProducer extends CamundaBpmProducer {
 
+  private static final Logger LOG = LoggerFactory.getLogger(StartProcessProducer.class);
+
   private final String processDefinitionKey;
 
   public StartProcessProducer(CamundaBpmEndpoint endpoint, Map<String, Object> parameters) {
@@ -49,7 +53,7 @@ public class StartProcessProducer extends CamundaBpmProducer {
 
   @Override
   public void close() {
-    log.info("Closing StartProcessProducer");
+    LOG.info("Closing StartProcessProducer");
     this.stop();
   }
 

--- a/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/common/CamelServiceTest.java
+++ b/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/common/CamelServiceTest.java
@@ -11,10 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.ProducerTemplate;
+import org.apache.camel.*;
 import org.camunda.bpm.camel.BaseCamelTest;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.context.BpmnExecutionContext;
@@ -50,7 +47,7 @@ public class CamelServiceTest extends BaseCamelTest {
       }
     };
     service.setProcessEngine(processEngine);
-    CamelContext camelContext = mock(CamelContext.class);
+    CamelContext camelContext = mock(ExtendedCamelContext.class);
     service.setCamelContext(camelContext);
 
     producerTemplate = mock(ProducerTemplate.class);

--- a/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/component/producer/MessageProducerTest.java
+++ b/camunda-bpm-camel-common/src/test/java/org/camunda/bpm/camel/component/producer/MessageProducerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.ExtendedExchange;
 import org.apache.camel.Message;
 import org.apache.camel.Producer;
 import org.camunda.bpm.camel.BaseCamelTest;
@@ -86,7 +87,7 @@ public class MessageProducerTest extends BaseCamelTest {
 
     @Test
     public void signalTransformBusinesskey() throws Exception {
-        Exchange exchange = mock(Exchange.class);
+        Exchange exchange = mock(ExtendedExchange.class);
         Message message = mock(Message.class);
         ExecutionQuery query = mock(ExecutionQuery.class);
         Execution execution = mock(Execution.class);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <camunda-bpm.version>7.12.0</camunda-bpm.version>
-    <camel.version>3.0.1</camel.version>
+    <camel.version>3.2.0</camel.version>
     <spring.framework.version>5.2.4.RELEASE</spring.framework.version>
     <fest.assert.version>2.0M10</fest.assert.version>
     <sl4j.version>1.7.30</sl4j.version>


### PR DESCRIPTION
This PR fixes some breaking changes when trying to use apache camel 3.2.0 (it's possible use it along with apache camel 3.3.0 too)

**Fix:**
- Some consumer and producer based class, such as: `ScheduledBatchPollingConsumer` does not contain log instance anymore, so the consumers and producers are initiating their own log instance.
Also, other classes have been changed to a constant called `LOG`, even when had their own log instance, following the standard (Apache camel release notes about this fix: https://camel.apache.org/manual/latest/camel-3x-upgrade-guide.html#_log_changed_to_private_static_log)
- Some `Exchange` methods have been moved to another interface (`ExtendedExchange`). `camunda-bpm-camel` uses some of those methods, so some classes have been modified to use `ExtendedExchange` instead (Apache camel release notes about this fix: https://camel.apache.org/manual/latest/camel-3x-upgrade-guide.html#_exchange)
- `TimePatternConvert` has been moved to other package.